### PR TITLE
`root` is undefined in some special environment

### DIFF
--- a/src/md5.js
+++ b/src/md5.js
@@ -13,6 +13,8 @@
   var NODE_JS = typeof process == 'object' && process.versions && process.versions.node;
   if (NODE_JS) {
     root = global;
+  }else if (!root){
+    root = {};
   }
   var COMMON_JS = !root.JS_MD5_TEST && typeof module == 'object' && module.exports;
   var AMD = typeof define == 'function' && define.amd;


### PR DESCRIPTION
In some special environment, such as WeChat micro app (微信小程序 in Chinese), `root` is undefined.

I gave it a default value.